### PR TITLE
Fix `connected?` function spec

### DIFF
--- a/lib/phoenix_client/socket.ex
+++ b/lib/phoenix_client/socket.ex
@@ -28,9 +28,9 @@ defmodule PhoenixClient.Socket do
     GenServer.stop(pid)
   end
 
-  @spec connected?(pid) :: boolean
-  def connected?(pid) do
-    GenServer.call(pid, :status) == :connected
+  @spec connected?(pid | atom) :: boolean
+  def connected?(pid_or_name) do
+    GenServer.call(pid_or_name, :status) == :connected
   end
 
   @doc false


### PR DESCRIPTION
dialyzer threw an error:
```
The call 'Elixir.PhoenixClient.Socket':'connected?'
         ('Elixir.PhoenixClient.Socket') breaks the contract
          (pid()) -> boolean()
```
when I tried to use this function with the process name. The function
call itself worked fine.