### PR TITLE
Add ability to send headers with original socket connection request

### DIFF
--- a/lib/phoenix_client/socket.ex
+++ b/lib/phoenix_client/socket.ex
@@ -88,6 +88,7 @@ defmodule PhoenixClient.Socket do
     transport_opts =
       Keyword.get(opts, :transport_opts, [])
       |> Keyword.put(:sender, self())
+      |> Keyword.put(:extra_headers, Keyword.get(opts, :headers))
 
     send(self(), :connect)
 


### PR DESCRIPTION
@mobileoverlord Thanks for this awesome library!

We're using headers in our authentication string. I'd love for `phoenix_client` to support this.

This works for our use case; let me know if you want me to change anything about the API. It appears that it's expected that `opts` would sometimes contain `:headers`, although I don't see that used anywhere so I'm not exactly sure if this is the right place to pass in these headers.

In practice:

```elixir
socket_opts = [
  url: "ws://localhost:4000/socket/websocket",
  headers: [{"foo", "fooval"}, {"bar", "barval"}]
]

{:ok, socket} = PhoenixClient.Socket.start_link(socket_opts)
```