### PR TITLE
Report back on connect/disconnect

### DIFF
--- a/test/phoenix_client_test.exs
+++ b/test/phoenix_client_test.exs
@@ -297,6 +297,17 @@ defmodule PhoenixClientTest do
     refute Socket.connected?(socket)
   end
 
+  test "socket reports back on connect if requested" do
+    config =
+      @socket_config
+      |> Keyword.put(:report_events, true)
+      |> Keyword.put(:reconnect_interval, 100)
+
+    {:ok, socket} = Socket.start_link(config)
+    wait_for_socket(socket)
+    assert_received {:phoenix_client, :connected}
+  end
+
   test "rejoin", context do
     endpoint = context[:endpoint]
     {:ok, socket} = Socket.start_link(@socket_config)


### PR DESCRIPTION
Hey @mobileoverlord, first off -- thanks again for this library. 😃 

This is a feature request to add some kind of mechanism to report back whenever connect/disconnect happens.

The use case is that our application connects to another Phoenix application on startup and joins some channels immediately. If there is a disconnection, it's great that `phoenix_client` automatically retries under the hood. But whenever the connection is reestablished, there's currently no way to be notified. I would like to be notified so that I can immediately re-join the channels.

Is that something you'd be open to? I'd be glad to re-work the code in any way if there's a better API and/or write tests. I don't think `report_back_pid` is a wonderful name, but it's the best I could think of in the moment. 😄 