### PR TITLE
Support dynamically generated headers

### DIFF
--- a/test/phoenix_client_test.exs
+++ b/test/phoenix_client_test.exs
@@ -330,6 +330,14 @@ defmodule PhoenixClientTest do
     assert %{"x-extra" => "value"} = headers
   end
 
+  test "headers can be dynamically generated" do
+    config = Keyword.put(@socket_config, :headers, fn -> [{"x-extra", "value"}] end)
+    {:ok, socket} = Socket.start_link(config)
+    wait_for_socket(socket)
+    {:ok, headers, _channel} = Channel.join(socket, "rooms:headers")
+    assert %{"x-extra" => "value"} = headers
+  end
+
   defp assert_message(pid, message, counter \\ 0)
   defp assert_message(_pid, _message, 10), do: false
 


### PR DESCRIPTION
I have a use case where socket authentication requires a header whose value is a timestamp that must be very close to "right now". (Or auth is rejected.)

```
X-CURRENT-TIMESTAMP: 1579880192
```

If I'm disconnected, `phoenix_client` will elegantly attempt to reconnect in the background... but with a timestamp header that will be rejected. ⛔️ 🙅‍♂ 

If we open up the API to also allow a zero-arity function to be sent for the `:headers` option, then the headers can be generated every time we attempt to connect.

```elixir
def timestamp do
  DateTime.utc_now
  |> DateTime.to_unix
  |> to_string
end

# Still supported 👍
PhoenixClient.Socket.start_link(
  headers: [
    {"x-current-timestamp", timestamp()}
  ]
)

# Now also supported 🆕 
PhoenixClient.Socket.start_link(
  headers: fn ->
    [
      {"x-current-timestamp", timestamp()}
    ]
  end
)
```