### PR TITLE
Ignore pong responses from websocket_client

### DIFF
--- a/lib/phoenix_client/transports/websocket.ex
+++ b/lib/phoenix_client/transports/websocket.ex
@@ -43,6 +43,12 @@ defmodule PhoenixClient.Transports.Websocket do
     {:ok, state}
   end
 
+  def websocket_handle({:pong, _msg}, _conn_state, state) do
+    # Ignore pong responses when :websocket_client is configured to send
+    # keepalive messages.
+    {:ok, state}
+  end
+
   def websocket_handle(other_msg, _req, state) do
     Logger.warn(fn -> "Unknown message #{inspect(other_msg)}" end)
     {:ok, state}


### PR DESCRIPTION
When `:websocket_client` is started with `keepalive: timeout`, it
actively pings the server using the standard Websocket mechanism. It
reports responses as `:pong`. Since it handles all of the timers,
`phoenix_client` doesn't need to do anything.

This commit ignores the `:pong` responses since they fill the log with
lines like this:

```
13:32:23.941 [warn]  Unknown message {:pong, "foo"}
```