### PR TITLE
Use SPDX identifier for Apache license

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -40,8 +40,8 @@ defmodule PhoenixClient.Mixfile do
 
   defp package do
     [
-      licenses: ["Apache 2.0"],
-      links: %{"Github" => "https://github.com/mobileoverlord/phoenix_client"}
+      licenses: ["Apache-2.0"],
+      links: %{"GitHub" => "https://github.com/mobileoverlord/phoenix_client"}
     ]
   end
 end


### PR DESCRIPTION
See https://spdx.org/licenses/ for identifier spelling/capitalization.
While tools help normalize license names when generating software BOMs,
it's nice when they start out with the SPDX identifiers.