### PR TITLE
Specify :ssl as a dependency and start with OTP

### DIFF
--- a/lib/phoenix_client/socket.ex
+++ b/lib/phoenix_client/socket.ex
@@ -51,9 +51,6 @@ defmodule PhoenixClient.Socket do
   ## Callbacks
   @impl true
   def init(opts) do
-    :crypto.start()
-    :ssl.start()
-
     transport = opts[:transport] || @default_transport
 
     json_library = Keyword.get(opts, :json_library, Jason)

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule PhoenixClient.Mixfile do
 
   def application do
     [
-      extra_applications: [:logger],
+      extra_applications: [:logger, :ssl],
       mod: {PhoenixClient, []}
     ]
   end


### PR DESCRIPTION
This makes the `:ssl` requirement explicit and ensures that it's
included in OTP releases. It also removes the manual application starts
for `:crypto` and `:ssl` since those will happen automatically now.