### PR TITLE
Terminate transport child on terminate

### DIFF
--- a/lib/phoenix_client/socket.ex
+++ b/lib/phoenix_client/socket.ex
@@ -226,6 +226,11 @@ defmodule PhoenixClient.Socket do
     end
   end
 
+  @impl true
+  def terminate(reason, state) do
+    transport_terminate(reason, state)
+  end
+
   defp transport_receive(message, %{
          channels: channels,
          serializer: serializer,
@@ -246,6 +251,13 @@ defmodule PhoenixClient.Socket do
        }) do
     send(pid, {:send, Message.encode!(serializer, message, json_library)})
   end
+
+  defp transport_terminate(reason, %{transport_pid: transport_pid})
+       when not is_nil(transport_pid) do
+    GenServer.stop(transport_pid, reason)
+  end
+
+  defp transport_terminate(_reason, _state), do: :ok
 
   defp close(reason, %{channels: channels, reconnect_timer: nil} = state) do
     state = %{state | status: :disconnected, channels: %{}}

--- a/test/phoenix_client_test.exs
+++ b/test/phoenix_client_test.exs
@@ -297,6 +297,21 @@ defmodule PhoenixClientTest do
     refute Socket.connected?(socket)
   end
 
+  test "stop transport when socket terminate" do
+    {:ok, socket} = Socket.start_link(@socket_config)
+    wait_for_socket(socket)
+
+    %{transport_pid: transport_pid} = :sys.get_state(socket)
+
+    refute is_nil(transport_pid)
+    assert Process.alive?(transport_pid)
+
+    :ok = Socket.stop(socket)
+
+    refute Process.alive?(socket)
+    refute Process.alive?(transport_pid)
+  end
+
   test "rejoin", context do
     endpoint = context[:endpoint]
     {:ok, socket} = Socket.start_link(@socket_config)


### PR DESCRIPTION
This PR solves #39 

On `:normal` stop, the child processes are not terminated. Let's trap the Socket process exit and manually stop the transport child to avoid dangling processes.