### PR TITLE
Add passive topic listen to Socket

### DIFF
--- a/lib/phoenix_client/socket.ex
+++ b/lib/phoenix_client/socket.ex
@@ -38,6 +38,10 @@ defmodule PhoenixClient.Socket do
     GenServer.call(pid, {:push, message})
   end
 
+  def listen(pid, topic, send_to) do
+    GenServer.call(pid, {:channel_listen, topic, send_to})
+  end
+
   @doc false
   def channel_join(pid, channel, topic, params) do
     GenServer.call(pid, {:channel_join, channel, topic, params})
@@ -133,6 +137,10 @@ defmodule PhoenixClient.Socket do
       {pid, _topic} ->
         {:reply, {:error, {:already_joined, pid}}, state}
     end
+  end
+
+  def handle_call({:channel_listen, topic, to}, _from, %{channels: channels} = state) do
+    {:reply, :ok, %{state | channels: Map.put(channels, topic, {to, :ignore})}}
   end
 
   @impl true


### PR DESCRIPTION
Absinthe has a unique protocol on top of pheonix wss to support GraphQl subscriptions, in that each subscription document sent creates a shadow channel that the client then has to manually subscribe to.  I couldn't find any existing function to support it using `PhoenixClient.Socket` so I implemented this, and it seems functional from my testing.

The process to create a working graphql subscription publishing to the current process becomes:

```elixir
with {:ok, %{"subscriptionId" => id}} <- Channel.push(absinthe, "doc", %{query: query, variables: variables}),
      do: Socket.listen(@socket_name, id, self())
```